### PR TITLE
Meetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ ShipSim takes a JSON file containing ship's positions and simulates the ships mo
 
 Install [elixir](https://elixir-lang.org/install.html).
 
-Requires v1.8+ of elixir due to DateTime.add/4. This can and will probably be rewritten to use other parts of DateTime instead of add to make this more backwardly compatible. Meanwhile, the fast way to get up and running is to use [asdf](https://asdf-vm.com) and install a newer version of elixir like so: `asdf install elixir 1.8.2`.
+Tested against v1.6.6 of Elixir after backporting DateTime.add/4 to use Unix seconds. Fails against v1.5.3. The fast way to get up and running with newer versions of Elixir is to use [asdf](https://asdf-vm.com) and install a newer version of elixir like so:
+
+* `asdf install elixir 1.8.2`
+* `asdf global elixir 1.8.2`
+* `asdf local elixir 1.8.2`
 
 ## Build
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,19 @@
+# AIS - Automatic Identification System
+
+AIS systems record position and other properties of ship movements in real time from low cost broadcasting sensors aboard ships.
+
+Governments, commercial providers, and even volunteer groups collate this data and provide it to shipping concerns and individual ships for the purposes of voyage planning, scheduling, collision avoidance, rescue and research.
+
+The US and Australian governments provide historical AIS data for free in a variety of formats. From 2015 onwards, the USA data sets are provided in CSV, making them easier to process. The Australian data sets and the USA data sets before 2015 are in ESRI File Geodatabase format which can be converted to other formats using [GDAL](https://www.osgeo.org/projects/gdal/), in particular, using the [ogr2ogr](https://github.com/OSGeo/gdal) command line.
+
+* Example: `ogr2ogr -overwrite -f CSV "test.csv" "test.gdb" "test_layer"`
+
+Once the data is in CSV format, converting it to GeoJSON or some other format is a straight forward mapping of headers to field keys in the target format.
+
+## References
+
+* [AIS Data Source Listing](https://mods.marin.nl/plugins/servlet/mobile?contentId=28770764#content/view/28770764)
+* [USA AIS Data](https://marinecadastre.gov/ais/)
+* [Australian AIS Data](https://en.wikipedia.org/wiki/Automatic_identification_system)
+
+

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -1,0 +1,25 @@
+# Implementing Parallel/Distributed Computation
+
+In Elixir/erlang there are many options for parallel and distributed
+computation. This is a list of the major types and the primary calls used to
+implement them.
+
+* Process/Node
+    - `Process.spawn/2, get/2, put/2, send/1, receive/1`
+    - `Node.spawn/2`
+* Task/Agent
+	- `Task.async/1, Task.yield_many/2`
+	- `Task.async_stream/3`
+	- `Agent.cast/2, Agent.get/3`
+* GenServer
+    - `GenServer.multi_call/4`
+* erlang
+	- `:rpc.multicall/4, :rpc.async_call/4, :rpc.yield/2`
+
+## Links
+
+* [Distributed Tasks](https://elixir-lang.org/getting-started/mix-otp/distributed-tasks-and-configuration.html)
+* [Task](https://elixir-lang.org/getting-started/mix-otp/task-and-gen-tcp.html)
+* [Agent](https://elixir-lang.org/getting-started/mix-otp/agent.html)
+* [GenServer](https://elixir-lang.org/getting-started/mix-otp/genserver.html)
+

--- a/lib/time_stamp.ex
+++ b/lib/time_stamp.ex
@@ -13,16 +13,23 @@ defmodule TimeStamp do
     end
   end
 
+  def add_seconds(dt, increment) do
+    unix_seconds = DateTime.to_unix(dt, :second) + increment
+    DateTime.from_unix(unix_seconds, :second)
+  end
+
   def round_seconds(tstring) do
     {:ok, dt} = Timex.parse(tstring, "{ISO:Extended:Z}")
     # add a half a minute which will then be truncated
-    newdt = DateTime.add(dt, 30)
+    # elixir 1.8+ has newdt = DateTime.add(dt, 30)
+    {:ok, newdt} = add_seconds(dt, 30)
     truncate_seconds(DateTime.to_iso8601(newdt))
   end
 
   def increment_time(tstring, increment) do
     {:ok, dt} = Timex.parse(tstring, "{ISO:Extended:Z}")
-    newdt = DateTime.add(dt, increment)
+    # newdt = DateTime.add(dt, increment)
+    {:ok, newdt} = add_seconds(dt, increment)
     round_seconds(DateTime.to_iso8601(newdt))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ShipSim.Mixfile do
   def project do
     [app: :shipsim,
      version: "0.1.0",
-     elixir: "~> 1.8",
+     elixir: "~> 1.6",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      escript: [main_module: ShipSim.CLI], #Added escript     


### PR DESCRIPTION
Backport DateTime add to use unix seconds instead, lower tested version to 1.6.6