### PR TITLE
Meetup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # bench data
 /bench/data
 
+# standard result outputs
+results.log
+
 # ---> Elixir
 # The directory Mix will write compiled artifacts to.
 /_build

--- a/bench/run_sim_bench.exs
+++ b/bench/run_sim_bench.exs
@@ -11,11 +11,11 @@ Benchee.run(
   },
   inputs: %{
     "pos_10" => "bench/data/pos10.json",
-    "pos_100" => "bench/data/pos100.json",
-    "pos_1k" => "bench/data/pos1000.json",
-    "pos_10k" => "bench/data/pos10000.json",
-    "pos_100k" => "bench/data/pos100000.json",
-    "pos_1M" => "bench/data/pos1000000.json",
+    # "pos_100" => "bench/data/pos100.json",
+    # "pos_1k" => "bench/data/pos1000.json",
+    # "pos_10k" => "bench/data/pos10000.json",
+    # "pos_100k" => "bench/data/pos100000.json",
+    # "pos_1M" => "bench/data/pos1000000.json",
     # "pos_10M" => "bench/data/pos10000000.json",
     # "pos_20M" => "bench/data/pos20000000.json"
   }

--- a/bench/run_sim_bench.exs
+++ b/bench/run_sim_bench.exs
@@ -15,7 +15,7 @@ Benchee.run(
     "pos_1k" => "bench/data/pos1000.json",
     "pos_10k" => "bench/data/pos10000.json",
     "pos_100k" => "bench/data/pos100000.json",
-    # "pos_1M" => "bench/data/pos1000000.json",
+    "pos_1M" => "bench/data/pos1000000.json",
     # "pos_10M" => "bench/data/pos10000000.json",
     # "pos_20M" => "bench/data/pos20000000.json"
   }

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -38,6 +38,29 @@ implement them.
       # TODO: calculate days run in parallel
       Enum.map( ...)
 
+## Bench Testing
+
+Read the instructions in `docs/data.md` to get and install the data.
+
+By default the software will run bench tests on only one data set, the smallest one
+having only 10 data points, and for a minimal time period of only one day.
+
+Edit the file `bench/run_sim_bench.exs` and uncomment larger data files in order
+to exercise the software on a larger number of ships.
+
+Edit the file `lib/shipsim.ex` and modify the following line in order
+to exercise the software on a longer time period:
+
+    "#{String.slice(first_time, 0..7)}01T23:59Z"
+
+Run the bench tests and capture the output so that you can see the bench results as
+they are written out to the command line:
+
+>
+> `mix run bench/run_sim_bench.exs > results.log`
+>
+
+
 ## Other Links
 
 * [Distributed Tasks](https://elixir-lang.org/getting-started/mix-otp/distributed-tasks-and-configuration.html)

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -24,6 +24,20 @@ implement them.
 * [erlang rpc](http://erlang.org/doc/man/rpc.html)
 	- `:rpc.multicall/4, :rpc.async_call/4, :rpc.yield/2`
 
+## ShipSim Parallel Touch Points
+
+* `shipsim\lib\shipsim.ex`
+    def advance_loop(ship_trackers, _timestamp, highest_time, closest_points) do
+      # advance ships
+      # TODO: advance ships in parallel
+      new_ship_trackers = Enum.map( ... )
+
+* `shipsim\lib\shipsim\days_run.ex`
+
+    def days_run(vessels) do
+      # TODO: calculate days run in parallel
+      Enum.map( ...)
+
 ## Other Links
 
 * [Distributed Tasks](https://elixir-lang.org/getting-started/mix-otp/distributed-tasks-and-configuration.html)

--- a/lib/shipsim.ex
+++ b/lib/shipsim.ex
@@ -85,12 +85,15 @@ defmodule ShipSim do
   end
 
   def advance_loop(ship_trackers, timestamp, highest_time, closest_points) when timestamp > highest_time do
+    IO.puts "End Loop :- Timestamp: #{timestamp} > Highest Time: #{highest_time}"
     {:ok, ship_trackers, closest_points}
   end
 
   def advance_loop(ship_trackers, _timestamp, highest_time, closest_points) do
     # advance ships
-    new_ship_trackers = Enum.map(ship_trackers,
+    # TODO: advance ships in parallel
+    new_ship_trackers = Enum.map(
+      ship_trackers,
       fn tracker ->
         ShipSim.Ship.advance(tracker, 60)
       end
@@ -235,26 +238,42 @@ defmodule ShipSim do
       IO.puts "Error : #{inspect vessels}"
       Process.exit(self(), :kill)
     end
+    ships = vessels["vessels"]
+    first_time = List.first(List.first(ships)["positions"])["timestamp"]
     # start time slice at the lowest time
-    # TODO: find the lowest timestamp
-    lowest_time = "2020-01-01T07:40Z"
+    # TODO: find the actual lowest timestamp
+    lowest_time =
+      if (String.starts_with?(first_time, "2020")) do
+        # use lowest time in TestData.json
+        "2020-01-01T07:40Z"
+      else
+        # use first day in this month
+        "#{String.slice(first_time, 0..7)}01T00:00Z"
+      end
     # end at the highest time
     # TODO: find the highest timestamp
-    highest_time = "2020-01-01T11:24Z"
+    highest_time =
+      if (String.starts_with?(first_time, "2020")) do
+        # use highest time in TestData.json
+        "2020-01-01T11:24Z"
+      else
+        # use last day in this month (2017-08-31T23:59Z)
+        "#{String.slice(first_time, 0..7)}31T23:59Z"
+      end
     # initialize all ship processes
     # using message passing loop
     # _ships = ShipSim.initSimLoop()
     # using Agent
     # using Task
     # using in memory objects
-    ships = vessels["vessels"]
-    ship_trackers = Enum.map(ships,
+    ship_trackers = Enum.map(
+      ships,
       fn ship ->
         start_position = List.first(ship["positions"])
         ship_tracker =
-          Map.put(ship, :position_index, 0) |>
-          Map.put(:current_time, lowest_time) |>
-          Map.put(:current_position, start_position)
+          Map.put(ship, :position_index, 0)
+          |> Map.put(:current_time, lowest_time)
+          |> Map.put(:current_position, start_position)
         ShipSim.Ship.where(ship_tracker, lowest_time)
       end
     )

--- a/lib/shipsim.ex
+++ b/lib/shipsim.ex
@@ -247,7 +247,7 @@ defmodule ShipSim do
         # use lowest time in TestData.json
         "2020-01-01T07:40Z"
       else
-        # use first day in this month
+        # start at the first day in this month
         "#{String.slice(first_time, 0..7)}01T00:00Z"
       end
     # end at the highest time
@@ -257,8 +257,10 @@ defmodule ShipSim do
         # use highest time in TestData.json
         "2020-01-01T11:24Z"
       else
-        # use last day in this month (2017-08-31T23:59Z)
-        "#{String.slice(first_time, 0..7)}31T23:59Z"
+        # highest date possible is the last day in the month (2017-08-31T23:59Z)
+        # "#{String.slice(first_time, 0..7)}31T23:59Z"
+        # only run for a single day initially
+        "#{String.slice(first_time, 0..7)}01T23:59Z"
       end
     # initialize all ship processes
     # using message passing loop

--- a/lib/shipsim/cli.ex
+++ b/lib/shipsim/cli.ex
@@ -38,12 +38,14 @@ defmodule ShipSim.CLI do
   end
 
   def parse_args(args) do
-    parse = OptionParser.parse(args, 
-                               switches: [
-                                 help: :boolean,
-                                 file: :string
-                                ],
-                               aliases: [h: :help])
+    parse = OptionParser.parse(
+      args, 
+      switches: [
+        help: :boolean,
+        file: :string
+      ],
+      aliases: [h: :help]
+    )
 
     case parse do
       {[help: true], _, _} -> :help

--- a/lib/shipsim/days_run.ex
+++ b/lib/shipsim/days_run.ex
@@ -1,6 +1,8 @@
 defmodule ShipSim.DaysRun do
   def days_run(vessels) do
-    Enum.map(vessels["vessels"],
+    # TODO: calculate days run in parallel
+    Enum.map(
+      vessels["vessels"],
       fn vessel ->
         %{"name" => vesselname, "positions" => positions} = vessel
         [firstposition|lastpositions] = positions


### PR DESCRIPTION
Fix start and end times to correspond to bench data when bench is running.
Set up most minimal bench to run initially (runs in 1 second on an i7 processor with 16 GB of memory)