### PR TITLE
Meetup

### DIFF
--- a/bench/run_sim_bench.exs
+++ b/bench/run_sim_bench.exs
@@ -32,6 +32,16 @@ Benchee.run(
 # Erlang 21.2
 #
 ##### With input pos_100k #####
+# After task-parallel advance() time slices (??slower)
+# Name             ips        average  deviation         median         99th %
+# task         0.00812       2.05 min     ±0.00%       2.05 min       2.05 min
+# serial       0.00727       2.29 min     ±0.00%       2.29 min       2.29 min
+# 
+# Comparison:
+# task         0.00812
+# serial       0.00727 - 1.12x slower +0.24 min
+#
+# After task-parallel days_run()
 # Name             ips        average  deviation         median         99th %
 # task          0.0179       0.93 min     Â±0.00%       0.93 min       0.93 min
 # serial        0.0147       1.14 min     Â±0.00%       1.14 min       1.14 min

--- a/bench/run_sim_bench.exs
+++ b/bench/run_sim_bench.exs
@@ -34,8 +34,8 @@ Benchee.run(
 ##### With input pos_100k #####
 # After task-parallel advance() time slices (??slower)
 # Name             ips        average  deviation         median         99th %
-# task         0.00812       2.05 min     �0.00%       2.05 min       2.05 min
-# serial       0.00727       2.29 min     �0.00%       2.29 min       2.29 min
+# task         0.00812       2.05 min   +/-0.00%       2.05 min       2.05 min
+# serial       0.00727       2.29 min   +/-0.00%       2.29 min       2.29 min
 # 
 # Comparison:
 # task         0.00812
@@ -43,8 +43,8 @@ Benchee.run(
 #
 # After task-parallel days_run()
 # Name             ips        average  deviation         median         99th %
-# task          0.0179       0.93 min     ±0.00%       0.93 min       0.93 min
-# serial        0.0147       1.14 min     ±0.00%       1.14 min       1.14 min
+# task          0.0179       0.93 min   +/-0.00%       0.93 min       0.93 min
+# serial        0.0147       1.14 min   +/-0.00%       1.14 min       1.14 min
 #
 # Comparison:
 # task          0.0179
@@ -54,7 +54,7 @@ Benchee.run(
 #
 ##### With input pos_1M #####
 # Name             ips        average  deviation         median         99th %
-# serial       0.00063      26.58 min     ±0.00%      26.58 min      26.58 min
+# serial       0.00063      26.58 min   +/-0.00%      26.58 min      26.58 min
 # 
 # Test results from 32 bit netbook : 1 million positions
 #
@@ -68,4 +68,4 @@ Benchee.run(
 #
 # ##### With input pos_1M #####
 # Name             ips        average  deviation         median         99th %
-# serial       0.00034      48.45 min     ±0.00%      48.45 min      48.45 min
+# serial       0.00034      48.45 min   +/-0.00%      48.45 min      48.45 min

--- a/docs/meetup.md
+++ b/docs/meetup.md
@@ -1,4 +1,5 @@
-Tuesday, June 4, 2019
+# Tuesday, June 4, 2019
+
 [Hands-on with Elixir!](https://www.meetup.com/Elixir-Calgary/events/261665388/)
 Hosted by Jonathan and 2 others
 
@@ -35,5 +36,3 @@ In this hands-on coding workshop, we'll:
 3. Generate test data to exercise the simulator
 4. Implement concurrent processing of ship movements
 5. Measure the running times of different implementations
-
-

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -11,26 +11,30 @@ computation. This is a list of the major types and the primary calls used to
 implement them.
 
 * [Process](https://hexdocs.pm/elixir/Process.html)/[Node](https://hexdocs.pm/elixir/Node.html)
-    - `Process.spawn/2, get/2, put/2, send/1, receive/1`
-    - `Node.spawn/2`
+  * `Process.spawn/2, get/2, put/2, send/1, receive/1`
+  * `Node.spawn/2`
 * [Task](https://hexdocs.pm/elixir/Task.html)/[Agent](https://hexdocs.pm/elixir/Agent.html)
-	- `Task.async/1, Task.yield_many/2`
-	- `Task.async_stream/3`
-	- `Agent.cast/2, Agent.get/3`
+  * `Task.async/1, Task.yield_many/2`
+  * `Task.async_stream/3`
+  * `Agent.cast/2, Agent.get/3`
 * [GenServer](https://hexdocs.pm/elixir/GenServer.html)
-    - `GenServer.multi_call/4`
+  * `GenServer.multi_call/4`
 * [Phoenix](https://hexdocs.pm/phoenix)
-    - [Channels](https://hexdocs.pm/phoenix/channels.html)
+  * [Channels](https://hexdocs.pm/phoenix/channels.html)
 * [erlang rpc](http://erlang.org/doc/man/rpc.html)
-	- `:rpc.multicall/4, :rpc.async_call/4, :rpc.yield/2`
+  * `:rpc.multicall/4, :rpc.async_call/4, :rpc.yield/2`
 
 ## ShipSim Parallel Touch Points
 
 * `shipsim\lib\shipsim.ex`
     def advance_loop(ship_trackers, _timestamp, highest_time, closest_points) do
-      # advance ships
       # TODO: advance ships in parallel
       new_ship_trackers = Enum.map( ... )
+
+    def all_ranges([ownship|others], results, method) do
+      # compute range and bearing
+      # TODO: range and bearing in parallel
+      new_ranges = Enum.map( ... )
 
 * `shipsim\lib\shipsim\days_run.ex`
 

--- a/lib/shipsim.ex
+++ b/lib/shipsim.ex
@@ -39,32 +39,98 @@ defmodule ShipSim do
     _lowest_time = "2020-01-01T07:40Z"
   end
 
-  def all_ranges([ownship|others], results) do
-    # compute ranges
-    new_ranges = Enum.map(others,
-      fn target ->
-        %{
-          range: range,
-          bearing: bearing
-        } = ShipSim.Ship.range_and_bearing(ownship, target)
-        # TODO: add reciprocal bearing from target back to ownship
-        # TODO: add check for crossing of these two legs
-        %{
-          ownship: ownship["name"],
-          target: target["name"],
-          time: target[:current_time],
-          own_position: ownship[:current_position],
-          trg_position: target[:current_position],
-          range: range,
-          bearing: bearing
-        }
+  def all_ranges([ownship|others], results, method) do
+    # compute range and bearing
+    # TODO: range and bearing in parallel
+    new_ranges =
+      if (false) do # method == "task" DISABLE - slows down extremely
+        tasks = Enum.map(
+          others,
+          fn target ->
+            Task.async(
+              fn ->
+                %{
+                  range: range,
+                  bearing: bearing
+                } = ShipSim.Ship.range_and_bearing(ownship, target)
+                # TODO: add reciprocal bearing from target back to ownship
+                # TODO: add check for crossing of these two legs
+                %{
+                  ownship: ownship["name"],
+                  target: target["name"],
+                  time: target[:current_time],
+                  own_position: ownship[:current_position],
+                  trg_position: target[:current_position],
+                  range: range,
+                  bearing: bearing
+                }
+              end
+            )
+          end
+        )
+        completedTasks = Task.yield_many(tasks, :infinity)
+        results = Enum.map(
+          completedTasks,
+          fn { task, result } ->
+            result || Task.shutdown(task, :brutal_kill)
+          end
+        )
+        Enum.map(
+          results,
+          fn result ->
+            case result do
+              { :ok, res } ->
+                res
+              { :exit, reason } ->
+                %{
+                  ownship: ownship["name"],
+                  target: reason,
+                  time: "",
+                  own_position: ownship[:current_position],
+                  trg_position: ownship[:current_position],
+                  range: 0.0,
+                  bearing: 0.0
+                }
+              _ ->
+                %{
+                  ownship: ownship["name"],
+                  target: "unkown error",
+                  time: "",
+                  own_position: ownship[:current_position],
+                  trg_position: ownship[:current_position],
+                  range: 0.0,
+                  bearing: 0.0
+                }
+            end
+          end
+        )    
+      else
+        Enum.map(
+          others,
+          fn target ->
+            %{
+              range: range,
+              bearing: bearing
+            } = ShipSim.Ship.range_and_bearing(ownship, target)
+            # TODO: add reciprocal bearing from target back to ownship
+            # TODO: add check for crossing of these two legs
+            %{
+              ownship: ownship["name"],
+              target: target["name"],
+              time: target[:current_time],
+              own_position: ownship[:current_position],
+              trg_position: target[:current_position],
+              range: range,
+              bearing: bearing
+            }
+          end
+        )
       end
-    )
     # add to results
     new_results = results ++ new_ranges
-    all_ranges(others, new_results)
+    all_ranges(others, new_results, method)
   end
-  def all_ranges(_, results) do
+  def all_ranges(_, results, _method) do
     # last ship has been compared to all the others
     results
   end
@@ -90,10 +156,9 @@ defmodule ShipSim do
   end
 
   def advance_loop(ship_trackers, _timestamp, highest_time, closest_points, method \\ "task") do
-    # advance ships
-    # TODO: advance ships in parallel
+    # advance ships, parallel and serial
     new_ship_trackers =
-      if (method == "task") do
+      if (false) do # method == "task" DISABLE - doubles execution time
         tasks = Enum.map(
           ship_trackers,
           fn tracker ->
@@ -134,7 +199,7 @@ defmodule ShipSim do
         )
       end
     # find the ranges between all ships
-    ranges = all_ranges(new_ship_trackers, [])
+    ranges = all_ranges(new_ship_trackers, [], method)
     # find the closest points of approach
     new_closest_points = update_closest_points(closest_points, ranges)
     new_timestamp = List.first(new_ship_trackers)[:current_time]

--- a/lib/shipsim/days_run.ex
+++ b/lib/shipsim/days_run.ex
@@ -95,7 +95,7 @@ defmodule ShipSim.DaysRun do
     )
   end
 
-  def days_run(vessels, method) do
+  def days_run(vessels, method \\ "task") do
     case method do
       "serial" ->
         days_run_serial(vessels)


### PR DESCRIPTION
Implement but disable task parallel range and advance functions
advance()  doubles the overall time, CPUs go to 50% throughout the run
range_and_bearing() causes the running time to go through the roof and CPU stays around 25%